### PR TITLE
fix: surface voice OTP errors to user instead of silent 500

### DIFF
--- a/lib/classes/authentication/authenticate.dart
+++ b/lib/classes/authentication/authenticate.dart
@@ -412,13 +412,14 @@ class Authenticate {
     }
   }
 
-  static Future<void> requestVoiceOtp(BuildContext context) async {
+  /// Returns null on success, or an error message string on failure.
+  static Future<String?> requestVoiceOtp(BuildContext context) async {
     try {
       final registrationData =
           context.read<RegistrationProvider>().registrationModel;
-      await AuthService.sendVoiceOtp(registrationData.phoneNumber!);
+      return await AuthService.sendVoiceOtp(registrationData.phoneNumber!);
     } catch (error) {
-      alertReturn(context, "Problem requesting voice call: $error");
+      return "Problem requesting voice call: $error";
     }
   }
 

--- a/lib/screens/auth/otp/code.dart
+++ b/lib/screens/auth/otp/code.dart
@@ -221,28 +221,47 @@ class _CodeAppwriteState extends State<CodeAppwrite> {
                                     ? null
                                     : () async {
                                         setState(() => isLoading = true);
-                                        await Authenticate.requestVoiceOtp(
-                                            context);
+                                        final error =
+                                            await Authenticate.requestVoiceOtp(
+                                                context);
                                         if (mounted) {
                                           setState(() => isLoading = false);
-                                          _startTimer();
-                                          ScaffoldMessenger.of(context)
-                                              .showSnackBar(
-                                            SnackBar(
-                                              content: const Text(
-                                                  '📞 Calling you now with your code…'),
-                                              backgroundColor:
-                                                  AppColors.navy,
-                                              behavior:
-                                                  SnackBarBehavior.floating,
-                                              shape: RoundedRectangleBorder(
-                                                  borderRadius:
-                                                      BorderRadius.circular(
-                                                          12)),
-                                              margin:
-                                                  const EdgeInsets.all(16),
-                                            ),
-                                          );
+                                          if (error == null) {
+                                            _startTimer();
+                                            ScaffoldMessenger.of(context)
+                                                .showSnackBar(
+                                              SnackBar(
+                                                content: const Text(
+                                                    '📞 Calling you now with your code…'),
+                                                backgroundColor: AppColors.navy,
+                                                behavior:
+                                                    SnackBarBehavior.floating,
+                                                shape: RoundedRectangleBorder(
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                            12)),
+                                                margin:
+                                                    const EdgeInsets.all(16),
+                                              ),
+                                            );
+                                          } else {
+                                            ScaffoldMessenger.of(context)
+                                                .showSnackBar(
+                                              SnackBar(
+                                                content: Text(error),
+                                                backgroundColor:
+                                                    AppColors.error,
+                                                behavior:
+                                                    SnackBarBehavior.floating,
+                                                shape: RoundedRectangleBorder(
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                            12)),
+                                                margin:
+                                                    const EdgeInsets.all(16),
+                                              ),
+                                            );
+                                          }
                                         }
                                       },
                                 child: Container(

--- a/lib/services/api/auth_service.dart
+++ b/lib/services/api/auth_service.dart
@@ -49,16 +49,18 @@ class AuthService {
     }
   }
 
-  static Future<bool> sendVoiceOtp(String phone) async {
+  static Future<String?> sendVoiceOtp(String phone) async {
     try {
       final response = await http.post(
         Uri.parse('${BaseUrl.baseUrl}/api/auth/sendVoiceOtp'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({'phoneNumber': phone}),
       );
-      return response.statusCode == 200;
-    } catch (_) {
-      return false;
+      if (response.statusCode == 200) return null; // null = success
+      final body = json.decode(response.body);
+      return body['error'] as String? ?? 'Failed to initiate voice call';
+    } catch (e) {
+      return 'Network error — could not request voice call';
     }
   }
 


### PR DESCRIPTION
sendVoiceOtp now returns null on success or the Twilio error string on failure. The 'Get a call instead' button shows a red snackbar with the actual error (e.g. trial account restriction) instead of doing nothing.