### PR TITLE
fix: restore push notifications for requests and posts

### DIFF
--- a/lib/screens/post/create_post.dart
+++ b/lib/screens/post/create_post.dart
@@ -99,7 +99,7 @@ class _PosterState extends State<Poster> {
     }
   }
 
-  void superbasePost(String Des, String img) async {
+  Future<void> superbasePost(String Des, String img) async {
     await supabase.from('Posts').insert({
       'Description': Des,
       'ImageUrl': img,
@@ -129,12 +129,12 @@ class _PosterState extends State<Poster> {
         await _uploadImageToSuperbase(_image);
       }
 
-      superbasePost(description, imageUrl ?? '');
+      await superbasePost(description, imageUrl ?? '');
 
-      PushNotifications.sendMessageToTopic(
+      await PushNotifications.sendMessageToTopic(
           topic: Provider.of<christProvider>(context, listen: false)
               .myMap['Project']?['ChurchName'],
-          title: 'Post',
+          title: 'New Post',
           body: description);
 
       Future.delayed(const Duration(seconds: 1), () {

--- a/lib/screens/prayer/create_prayer.dart
+++ b/lib/screens/prayer/create_prayer.dart
@@ -4,6 +4,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../classes/church_init.dart';
 import '../../classes/prayer_class.dart';
+import '../../classes/push_notification/notification.dart';
 import '../../componants/global_booking.dart';
 import '../../providers/url_provider.dart';
 import '../../theme/app_colors.dart';
@@ -196,11 +197,15 @@ class _CreatePrayerState extends State<CreatePrayer> {
                       // ── Submit button ───────────────────────────────────
                       GestureDetector(
                         onTap: () async {
-                          setState(() {
-                            isLoading = true;
-                          });
+                          final prayer = prayerController.text.trim();
+                          if (prayer.isEmpty) return;
 
-                          final prayer = prayerController.text;
+                          setState(() => isLoading = true);
+
+                          final churchName =
+                              Provider.of<christProvider>(context, listen: false)
+                                      .myMap['Project']?['ChurchName'] ??
+                                  '';
 
                           await superbaseProduct(
                             prayer,
@@ -213,13 +218,16 @@ class _CreatePrayerState extends State<CreatePrayer> {
                             ).currentUserImage,
                           );
 
-                          setState(() {
-                            isLoading = false;
-                          });
+                          // Notify all community members about the new request
+                          await PushNotifications.sendMessageToTopic(
+                            topic: churchName,
+                            title: 'New Request',
+                            body: '${currentUser['UserName'] ?? 'Someone'} submitted a request: $prayer',
+                          );
 
+                          setState(() => isLoading = false);
                           prayerController.clear();
-
-                          Navigator.of(context).pop();
+                          if (context.mounted) Navigator.of(context).pop();
                         },
                         child: Container(
                           width: double.infinity,


### PR DESCRIPTION
- create_prayer: add missing PushNotifications.sendMessageToTopic call that was never wired up during the v2 redesign
- create_post: add await to sendMessageToTopic and superbasePost (both were fire-and-forget, causing silent failures)
- create_post: change superbasePost return type void → Future<void>
  so await works correctly