### PR TITLE
fix: apply convertName to topic before sending notification

### DIFF
--- a/lib/classes/push_notification/notification.dart
+++ b/lib/classes/push_notification/notification.dart
@@ -212,7 +212,9 @@ class PushNotifications {
     required String title,
     required String body,
   }) async {
+    // Must match the converted name used at subscription time
+    final convertedTopic = convertName(topic);
     return notificationService.sendNotificationToTopic(
-        topic: topic, title: title, body: body);
+        topic: convertedTopic, title: title, body: body);
   }
 }


### PR DESCRIPTION
Subscribe uses convertName() → 'sunrise_community' but send was passing the raw church name 'Sunrise Community'. FCM topics are case-sensitive so they never matched and no notifications arrived.