### PR TITLE
fix: use ProjectId as FCM topic instead of hardcoded 'church'

### DIFF
--- a/lib/screens/post/create_post.dart
+++ b/lib/screens/post/create_post.dart
@@ -133,7 +133,8 @@ class _PosterState extends State<Poster> {
 
       await PushNotifications.sendMessageToTopic(
           topic: Provider.of<christProvider>(context, listen: false)
-              .myMap['Project']?['ChurchName'],
+                  .myMap['Project']?['ProjectId']?.toString() ??
+              '',
           title: 'New Post',
           body: description);
 

--- a/lib/screens/prayer/create_prayer.dart
+++ b/lib/screens/prayer/create_prayer.dart
@@ -202,9 +202,9 @@ class _CreatePrayerState extends State<CreatePrayer> {
 
                           setState(() => isLoading = true);
 
-                          final churchName =
+                          final orgId =
                               Provider.of<christProvider>(context, listen: false)
-                                      .myMap['Project']?['ChurchName'] ??
+                                      .myMap['Project']?['ProjectId']?.toString() ??
                                   '';
 
                           await superbaseProduct(
@@ -220,7 +220,7 @@ class _CreatePrayerState extends State<CreatePrayer> {
 
                           // Notify all community members about the new request
                           await PushNotifications.sendMessageToTopic(
-                            topic: churchName,
+                            topic: orgId,
                             title: 'New Request',
                             body: '${currentUser['UserName'] ?? 'Someone'} submitted a request: $prayer',
                           );

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -116,10 +116,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
   Future<bool> updateNotification(bool value) async {
     try {
+      final orgId =
+          Provider.of<christProvider>(context, listen: false)
+                  .myMap['Project']?['ProjectId']?.toString() ??
+              '';
       if (value) {
-        await PushNotifications.subscribeToChurchTopic('church');
+        await PushNotifications.subscribeToChurchTopic(orgId);
       } else {
-        await PushNotifications.unsubscribeFromChurchTopic('church');
+        await PushNotifications.unsubscribeFromChurchTopic(orgId);
       }
       return true;
     } catch (_) {


### PR DESCRIPTION
Profile was subscribing to topic 'church' (hardcoded literal) instead of the actual org ID. Subscribe and send must use the same value — now all three files use ProjectId from christProvider consistently.