### PR TITLE
fix: move navigatorKey declaration after all imports (dart compile er…

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,9 +4,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:master/classes/push_notification/notification.dart';
-
-/// Global navigator key — lets PushNotifications show toasts from anywhere.
-final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 import 'package:master/providers/message_provider.dart';
 import 'package:master/providers/registration_provider.dart';
 import 'package:master/providers/user_data_provider.dart';
@@ -38,7 +35,8 @@ import 'theme/font_manager.dart';
 import 'theme/loading_manager.dart';
 import 'theme/app_theme.dart';
 
-
+/// Global navigator key — lets PushNotifications show toasts from anywhere.
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
…ror)

Dart requires all import directives before any declarations. The GlobalKey was inserted mid-imports causing 'Directives must appear before any declarations' error on web build.