### PR TITLE
fix: resolve FCM topic mismatch and toast crash

### DIFF
--- a/lib/classes/push_notification/notification.dart
+++ b/lib/classes/push_notification/notification.dart
@@ -67,15 +67,24 @@ class PushNotifications {
           return;
         }
 
-        // Show branded in-app toast via the global navigator key
+        // Show branded in-app toast via the global navigator key.
+        // Use a post-frame callback so the overlay is guaranteed to be mounted.
         final ctx = navigatorKey.currentContext;
         if (ctx != null) {
-          showConnectToast(
-            context: ctx,
-            title: title,
-            body: body,
-            type: type,
-          );
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            final liveCtx = navigatorKey.currentContext;
+            if (liveCtx == null) return;
+            try {
+              showConnectToast(
+                context: liveCtx,
+                title: title,
+                body: body,
+                type: type,
+              );
+            } catch (e) {
+              debugPrint('Toast show error: $e');
+            }
+          });
         }
       });
 

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -51,6 +51,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   String number = '';
   bool notificationMessage = false;
   bool notificationPost = false;
+  String _uniqueChurchId = '';
 
   @override
   void initState() {
@@ -68,6 +69,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       setState(() {
         number = user.phoneNumber ?? '';
         _role  = user.role ?? '';
+        _uniqueChurchId = user.uniqueChurchId ?? '';
       });
       if (number.isEmpty) throw Exception('User phone number not found');
       UserDetails? userDetails =
@@ -115,10 +117,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
     });
   }
 
-  String get _orgId =>
-      Provider.of<christProvider>(context, listen: false)
-              .myMap['Project']?['ProjectId']?.toString() ??
-          '';
+  /// Use the actual organisation UUID from the JWT — same value the message
+  /// screen uses when it calls buildTopic, so subscribe/send topics match.
+  String get _orgId => _uniqueChurchId;
 
   Future<bool> updateChatNotification(bool value) async {
     try {

--- a/lib/widgets/common/connect_notification_toast.dart
+++ b/lib/widgets/common/connect_notification_toast.dart
@@ -81,12 +81,15 @@ class _ConnectToastState extends State<_ConnectToast>
     );
 
     _slideCtrl.forward();
-    _progressCtrl.forward().then((_) => _dismiss());
+    _progressCtrl.forward().then((_) {
+      if (mounted) _dismiss();
+    });
   }
 
   void _dismiss() async {
+    if (!mounted) return;
     await _slideCtrl.reverse();
-    widget.onDismiss();
+    if (mounted) widget.onDismiss();
   }
 
   @override


### PR DESCRIPTION
- profile_screen: _orgId now reads uniqueChurchId from the JWT token (was using static Appwrite ProjectId, so subscribe/send topics never matched)
- notification.dart: wrap showConnectToast in addPostFrameCallback so the overlay is guaranteed mounted; catch errors to prevent minified:IV<void> crash
- connect_notification_toast: guard _dismiss() with mounted checks to prevent reverse() calls on a disposed AnimationController