### PR TITLE
fix: replace withValues(alpha:) with withOpacity() for Flutter 3.24 c…

### DIFF
--- a/lib/extra/contact_screen.dart
+++ b/lib/extra/contact_screen.dart
@@ -408,7 +408,7 @@ class _SearchResultsPanel extends StatelessWidget {
                   children: [
                     Icon(Icons.search_off_rounded,
                         size: 40,
-                        color: colors.primary.withValues(alpha: 0.3)),
+                        color: colors.primary.withOpacity(0.3)),
                     const SizedBox(height: 10),
                     Text('No messages found',
                         style: AppTypography.bodyText.copyWith(

--- a/lib/screens/chat/message_screen.dart
+++ b/lib/screens/chat/message_screen.dart
@@ -540,7 +540,7 @@ class _MessageScreenState extends State<MessageScreen> {
             if (_isJumpingToMessage)
               Positioned.fill(
                 child: Container(
-                  color: Colors.black.withValues(alpha: 0.35),
+                  color: Colors.black.withOpacity(0.35),
                   child: Center(
                     child: Container(
                       padding: const EdgeInsets.symmetric(
@@ -651,7 +651,7 @@ class _MessageScreenState extends State<MessageScreen> {
           key: msgKey,
           duration: const Duration(milliseconds: 300),
           color: isHighlighted
-              ? AppColors.purple.withValues(alpha: 0.15)
+              ? AppColors.purple.withOpacity(0.15)
               : Colors.transparent,
           child: bubble,
         );

--- a/lib/screens/event/create_event.dart
+++ b/lib/screens/event/create_event.dart
@@ -369,7 +369,7 @@ class _CreateEventState extends State<CreateEvent> {
                   borderRadius: BorderRadius.circular(AppSpacing.radiusPill),
                   boxShadow: [
                     BoxShadow(
-                      color: AppColors.purple.withValues(alpha: 0.35),
+                      color: AppColors.purple.withOpacity(0.35),
                       blurRadius: 16,
                       offset: const Offset(0, 4),
                     ),

--- a/lib/screens/post/post_screen.dart
+++ b/lib/screens/post/post_screen.dart
@@ -1203,7 +1203,7 @@ class _EventCard extends StatelessWidget {
                               child: Container(
                                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                                 decoration: BoxDecoration(
-                                  color: AppColors.error.withValues(alpha: 0.1),
+                                  color: AppColors.error.withOpacity(0.1),
                                   borderRadius: BorderRadius.circular(8),
                                 ),
                                 child: Icon(Icons.delete_outline_rounded,

--- a/lib/widgets/home/notification_centre.dart
+++ b/lib/widgets/home/notification_centre.dart
@@ -97,7 +97,7 @@ class _NotificationCentreState extends State<NotificationCentre> {
       width: 42,
       height: 42,
       decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
+        color: color.withOpacity(0.12),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Icon(icon, size: 20, color: color),
@@ -175,7 +175,7 @@ class _NotificationCentreState extends State<NotificationCentre> {
                           children: [
                             Icon(Icons.notifications_off_rounded,
                                 size: 40,
-                                color: AppColors.textMuted.withValues(alpha: 0.4)),
+                                color: AppColors.textMuted.withOpacity(0.4)),
                             const SizedBox(height: 10),
                             Text('No notifications yet',
                                 style: AppTypography.bodyText.copyWith(


### PR DESCRIPTION
…ompat

withValues() was introduced in Flutter 3.27 — CI runs 3.24.4 which does not have it, causing dart2js compilation failure.